### PR TITLE
Merge prometheus/prometheus main  changes  Mar 22, 2021 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 version: 2.1
 
 orbs:
-  prometheus: prometheus/prometheus@0.10.0
+  prometheus: prometheus/prometheus@0.11.0
   go: circleci/go@0.2.0
   win: circleci/windows@2.3.0
 
@@ -132,44 +132,17 @@ workflows:
         filters:
           tags:
             only: /.*/
-    # Build pipeline for PRs.
-    - prometheus/build_platform:
+    - prometheus/build:
         name: build
-        filters:
-          tags:
-            only: /.*/
-            ignore: /^v[0-9]+(\.[0-9]+){2}(-.+|[^-.]*)$/
-        matrix:
-          parameters:
-            platform:
-            # - aix # Currently doesn't build.
-            - darwin
-            - dragonfly
-            - freebsd
-            - illumos
-            - linux
-            - netbsd
-            - openbsd
-            - windows
-    # Build pipeline for main releases.
-    - prometheus/build:
-        name: build-main
-        filters:
-          branches:
-            only: main
-    # Build pipeline for versioned releases.
-    - prometheus/build:
-        name: build-release
+        parallelism: 12
         filters:
           tags:
             only: /^v[0-9]+(\.[0-9]+){2}(-.+|[^-.]*)$/
-          branches:
-            ignore: /.*/
     - prometheus/publish_main:
         context: org-context
         requires:
         - test
-        - build-main
+        - build
         filters:
           branches:
             only: main
@@ -178,7 +151,7 @@ workflows:
         context: org-context
         requires:
         - test
-        - build-release
+        - build
         filters:
           tags:
             only: /^v[0-9]+(\.[0-9]+){2}(-.+|[^-.]*)$/

--- a/.promu.yml
+++ b/.promu.yml
@@ -27,25 +27,11 @@ tarball:
         - npm_licenses.tar.bz2
 crossbuild:
     platforms:
-        - linux/amd64
-        - linux/386
-        - darwin/amd64
-        - windows/amd64
-        - windows/386
-        - freebsd/amd64
-        - freebsd/386
-        - openbsd/amd64
-        - openbsd/386
-        - netbsd/amd64
-        - netbsd/386
-        - dragonfly/amd64
-        - linux/arm
-        - linux/arm64
-        - freebsd/arm
-        - openbsd/arm
-        - linux/mips64
-        - linux/mips64le
-        - netbsd/arm
-        - linux/ppc64
-        - linux/ppc64le
-        - linux/s390x
+        - darwin
+        - dragonfly
+        - freebsd
+        - illumos
+        - linux
+        - netbsd
+        - openbsd
+        - windows

--- a/Makefile.common
+++ b/Makefile.common
@@ -78,7 +78,7 @@ ifneq ($(shell which gotestsum),)
 endif
 endif
 
-PROMU_VERSION ?= 0.10.0
+PROMU_VERSION ?= 0.11.1
 PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_VERSION)/promu-$(PROMU_VERSION).$(GO_BUILD_PLATFORM).tar.gz
 
 GOLANGCI_LINT :=

--- a/config/config.go
+++ b/config/config.go
@@ -117,7 +117,7 @@ var (
 	DefaultAlertmanagerConfig = AlertmanagerConfig{
 		Scheme:           "http",
 		Timeout:          model.Duration(10 * time.Second),
-		APIVersion:       AlertmanagerAPIVersionV1,
+		APIVersion:       AlertmanagerAPIVersionV2,
 		HTTPClientConfig: config.DefaultHTTPClientConfig,
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -785,7 +785,7 @@ var expectedConf = &Config{
 			{
 				Scheme:           "https",
 				Timeout:          model.Duration(10 * time.Second),
-				APIVersion:       AlertmanagerAPIVersionV1,
+				APIVersion:       AlertmanagerAPIVersionV2,
 				HTTPClientConfig: config.DefaultHTTPClientConfig,
 				ServiceDiscoveryConfigs: discovery.Configs{
 					discovery.StaticConfig{

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1755,7 +1755,7 @@ through the `__alerts_path__` label.
 [ timeout: <duration> | default = 10s ]
 
 # The api version of Alertmanager.
-[ api_version: <string> | default = v1 ]
+[ api_version: <string> | default = v2 ]
 
 # Prefix for the HTTP path alerts are pushed to.
 [ path_prefix: <path> | default = / ]

--- a/notifier/notifier_test.go
+++ b/notifier/notifier_test.go
@@ -454,7 +454,7 @@ func TestReload(t *testing.T) {
 					},
 				},
 			},
-			out: "http://alertmanager:9093/api/v1/alerts",
+			out: "http://alertmanager:9093/api/v2/alerts",
 		},
 	}
 
@@ -504,7 +504,7 @@ func TestDroppedAlertmanagers(t *testing.T) {
 					},
 				},
 			},
-			out: "http://alertmanager:9093/api/v1/alerts",
+			out: "http://alertmanager:9093/api/v2/alerts",
 		},
 	}
 


### PR DESCRIPTION
1.This commit uses the CircleCI parallelism features, combined with the
last changes in promu that enables this.

Now all the pull requests will be built with all the platforms again, in
less than 20 minutes.

A side effect is that we now build Prometheus for 7 more os/arch combos:
darwin-arm64 / illumos-amd64 / linux-mips / linux-mipsle /
freebsd-arm64 / netbsd-arm64 / openbsd-arm64

2.Switch to alertmanager api v2